### PR TITLE
fix: Enables TextMesh on hint text.

### DIFF
--- a/Udacity Carnival/Assets/UdacityVR/Scenes/Carnival.unity
+++ b/Udacity Carnival/Assets/UdacityVR/Scenes/Carnival.unity
@@ -1346,7 +1346,7 @@ Transform:
   - {fileID: 1072786418}
   - {fileID: 1359439100}
   m_Father: {fileID: 1079474566}
-  m_RootOrder: 1
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 100, z: 0}
 --- !u!1 &201063177
 GameObject:
@@ -2504,7 +2504,7 @@ Transform:
   - {fileID: 716589451}
   - {fileID: 728846004}
   m_Father: {fileID: 1079474566}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!114 &337220844
 MonoBehaviour:
@@ -3701,6 +3701,7 @@ Transform:
   - {fileID: 1491395566}
   - {fileID: 71884316}
   - {fileID: 1564350855}
+  - {fileID: 1068619818}
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -5697,7 +5698,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1079474566}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &979499681
 BoxCollider:
@@ -6066,12 +6067,12 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1068619816}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.78}
   m_LocalScale: {x: 2.2, y: 2.2, z: 2.2}
   m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_Father: {fileID: 597092649}
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1072786417
 GameObject:
@@ -6141,10 +6142,10 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 266290499}
-  - {fileID: 195114540}
   - {fileID: 979499680}
   - {fileID: 337220843}
   - {fileID: 2014779497}
+  - {fileID: 195114540}
   - {fileID: 124125368}
   m_Father: {fileID: 0}
   m_RootOrder: 2
@@ -17010,7 +17011,7 @@ GameObject:
   - component: {fileID: 1857368338}
   - component: {fileID: 1857368337}
   m_Layer: 0
-  m_Name: ???
+  m_Name: DoubleClickMeForAHint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -17022,7 +17023,7 @@ MonoBehaviour:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1857368336}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -806885394, guid: 89f0137620f6af44b9ba852b4190e64e, type: 3}
   m_Name: 
@@ -17111,11 +17112,11 @@ MonoBehaviour:
     lineCount: 1
     pageCount: 1
     materialCount: 1
-  m_havePropertiesChanged: 1
+  m_havePropertiesChanged: 0
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_isInputParsingRequired: 1
+  m_isInputParsingRequired: 0
   m_inputSource: 0
   m_hasFontAssetChanged: 0
   m_renderer: {fileID: 1857368339}
@@ -17187,7 +17188,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -18120,7 +18121,7 @@ Transform:
   - {fileID: 1600564242}
   - {fileID: 159450727}
   m_Father: {fileID: 1079474566}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!114 &2014779498
 MonoBehaviour:


### PR DESCRIPTION
Enables TextMesh on hint text to make it easier to see.
Renames the hint game object to something a little easier to find.
Reorders the list of carnival games so students can work down the list
in order to complete the project.